### PR TITLE
Allow Wix embeds in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,24 @@
+const DEFAULT_FRAME_ANCESTORS = [
+  "'self'",
+  "https://editor.wix.com",
+  "https://www.wix.com",
+  "https://*.wixsite.com",
+  "https://*.editorx.io"
+];
+
+function getFrameAncestors() {
+  const extra = process.env.ALLOWED_FRAME_ANCESTORS?.split(/[,\s]+/)
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  const merged = new Set(DEFAULT_FRAME_ANCESTORS);
+  if (extra) {
+    for (const origin of extra) merged.add(origin);
+  }
+
+  return Array.from(merged).join(" ");
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
@@ -5,11 +26,13 @@ const nextConfig = {
       {
         source: "/(.*)",
         headers: [
-          // Allow Wix editor + wixsite previews to embed your app
           {
             key: "Content-Security-Policy",
-            value:
-              "frame-ancestors https://editor.wix.com https://*.wixsite.com 'self';",
+            value: `frame-ancestors ${getFrameAncestors()};`
+          },
+          {
+            key: "X-Frame-Options",
+            value: "ALLOWALL"
           }
         ]
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,20 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- expand the Content-Security-Policy frame-ancestors list and allow configuration via the ALLOWED_FRAME_ANCESTORS environment variable so published Wix domains can embed the widget
- override the default X-Frame-Options header so Vercel no longer blocks the iframe when served on Wix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e439716204832ba59c1d0436640171